### PR TITLE
Add copy button next to code blocks

### DIFF
--- a/src/mkdocs.yml
+++ b/src/mkdocs.yml
@@ -39,7 +39,7 @@ theme:
     # - content.action.edit
     # - content.action.view
     # - content.code.annotate
-    # - content.code.copy
+    - content.code.copy
     # # - content.code.select
     # # - content.footnote.tooltips
     # # - content.tabs.link


### PR DESCRIPTION
A small change to add a copy button next to the code blocks in the whole documentation