### PR TITLE
Add `CNAME` file to persist serving of docs site

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -68,3 +68,4 @@ jobs:
         with:
           personal_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./src/site
+          cname: dev.getml.com


### PR DESCRIPTION
According to [GitHub docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain), there should be a `CNAME` file in the root directory of the source branch of the repo.  

When we add a custom domain in the repo settings, this file gets created in our `gh-pages` branch. However, when we deploy a new version of the documentation, the file gets deleted. 

To add the `CNAME` file automatically every time docs are deployed, the PR uses [`cname` option](peaceiris/actions-gh-pages@v4) of the `peaceiris/actions-gh-pages@v4` action we are using to deploy the docs.