### PR TITLE
Ensure one run of workflow executes at a time

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -6,8 +6,11 @@ on:
       - develop
     tags:
       - 'v*'
-
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
### Problem
A [job](https://github.com/getml/getml-docs/actions/runs/10142440339) failed earlier because two instances of the build workflow were running at the same time.

Both instances fetched the latest commit on `gh-pages`. However, by the time the second instance, tried to push its changes to `gh-pages`, the first stance had already updated the `gh-pages` branch.

Consequently, the second instance gave the error 'Updates were rejected because the remote contains work that you do not have locally.'

### Solution
The situation can be avoided in the future by introducing [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency), which will ensure that only one instance of the workflow runs for a given git ref (For example: `refs/heads/develop`). The `cancel-in-progress: true` attribute will cancel the first (currently in progress) instance and only let the second instance run.