### PR TITLE
Fix link to message-us page

### DIFF
--- a/src/docs/enterprise/benefits.md
+++ b/src/docs/enterprise/benefits.md
@@ -33,4 +33,4 @@ GetML Enterprise offers a suite of cutting-edge ML algorithms that surpass both 
 
 Request a meeting to explore the potential of GetML Relational Learning for your business application.
 
-[Let's talk](../contact/message-us){.md-button .md-button--primary}
+[Let's talk](../contact/message-us.md){.md-button .md-button--primary}


### PR DESCRIPTION
The link under the 'Let's talk' button was still broken here: https://dev.getml.com/dev/enterprise/benefits/#talk-to-sales