### PR TITLE
display types of placeholder object

### DIFF
--- a/src/docs/reference/data/index.md
+++ b/src/docs/reference/data/index.md
@@ -37,12 +37,8 @@ title: Data
     options:
       heading_level: 2
       show_root_full_path: false
-      show_root_heading: true
-      show_root_toc_entry: true
       
 ::: getml.data.TimeStampsType
     options:
       heading_level: 2
       show_root_full_path: false
-      show_root_heading: true
-      show_root_toc_entry: true

--- a/src/docs/reference/data/index.md
+++ b/src/docs/reference/data/index.md
@@ -32,3 +32,17 @@ title: Data
     options:
       heading_level: 2
       show_root_full_path: false
+
+::: getml.data.OnType
+    options:
+      heading_level: 2
+      show_root_full_path: false
+      show_root_heading: true
+      show_root_toc_entry: true
+      
+::: getml.data.TimeStampsType
+    options:
+      heading_level: 2
+      show_root_full_path: false
+      show_root_heading: true
+      show_root_toc_entry: true

--- a/src/docs/reference/data/placeholder.md
+++ b/src/docs/reference/data/placeholder.md
@@ -1,1 +1,13 @@
 ::: getml.data.Placeholder
+::: getml.data.TimeStampsType
+    options:
+      heading_level: 2
+      show_root_full_path: false
+      show_root_heading: true
+      show_root_toc_entry: true
+::: getml.data.OnType
+    options:
+      heading_level: 2
+      show_root_full_path: false
+      show_root_heading: true
+      show_root_toc_entry: true

--- a/src/docs/reference/data/placeholder.md
+++ b/src/docs/reference/data/placeholder.md
@@ -1,13 +1,1 @@
 ::: getml.data.Placeholder
-::: getml.data.TimeStampsType
-    options:
-      heading_level: 2
-      show_root_full_path: false
-      show_root_heading: true
-      show_root_toc_entry: true
-::: getml.data.OnType
-    options:
-      heading_level: 2
-      show_root_full_path: false
-      show_root_heading: true
-      show_root_toc_entry: true


### PR DESCRIPTION
I am not sure, if this is the correct place of documenting the two types, but I feel it is most appropriate.

https://gitlab.com/getml/all/monorepo/-/merge_requests/new?merge_request%5Bsource_branch%5D=resolve-placeholder-types