### PR TITLE
Validate external urls

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -18,6 +18,7 @@ jobs:
     environment: dev
     env:
       NOTEBOOKS_INCLUDE: '*.ipynb'
+      ENABLED_HTMLPROOFER: True
     steps:
       - name: Checkout getml-docs repo
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "black~=24.4",
   "mike~=2.1",
   "mkdocs-redirects~=1.2",
-  "mkdocs-jupyter"
+  "mkdocs-jupyter",
+  "mkdocs-htmlproofer-plugin~=1.2"
 ]
 python = "3.11"

--- a/src/docs/install/remote_access.md
+++ b/src/docs/install/remote_access.md
@@ -18,7 +18,7 @@ To run the getML software on a remote server, you should ensure the following:
 
 ### Remote Installation
 
-If all conditions are met, download the Linux version of the getML Suite from [getml.com](https://www.getml.com/download) and copy it to the remote server.
+If all conditions are met, download the Linux version of the getML Suite from [archives](packages/archive.md) and copy it to the remote server.
 ```bash
 scp getml-VERSION-linux.tar.gz USER@IP:
 ```

--- a/src/docs/user_guide/index.md
+++ b/src/docs/user_guide/index.md
@@ -45,4 +45,4 @@ Conveniently, it is divided in three levels of detail:
 
 </div>
 
-In addition, you can also check out our [blog articles and case studies](https://www.getml.com/blog) where we share insights from our latest projects. 
+

--- a/src/docs/user_guide/walkthrough/index.md
+++ b/src/docs/user_guide/walkthrough/index.md
@@ -376,7 +376,7 @@ This very much resembles the ad hoc definition we tried in the beginning. The co
 
 This guide has shown you the very basics of getML. Starting with raw data, you have completed a full project including feature engineering and linear regression using an automated end-to-end pipeline. The most tedious part of this process - finding the right aggregations and subconditions to construct a feature table from the relational data model - was also included in this pipeline.
 
-But there’s more! [Related articles](https://www.getml.com/blog) show application
+But there’s more! [Examples][examples-index] show application
 of getML on real world data sets.
 
 Also, don’t hesitate to [contact us][contact-page] with your feedback.

--- a/src/mkdocs.yml
+++ b/src/mkdocs.yml
@@ -141,6 +141,14 @@ plugins:
       remove_tag_config:
         remove_cell_tags:
           - remove_cell_on_docs
+  - htmlproofer:
+      enabled: !ENV [ENABLED_HTMLPROOFER, False]
+      raise_error_after_finish: True
+      ignore_urls:
+        - https://static.getml.com/download/1.5.0/*
+        - https://storage.googleapis.com/static.getml.com/download/1.5.0/*
+        - localhost:8080/*
+        - mailto:*
 
 hooks:
   - docs/examples/get_notebooks.py


### PR DESCRIPTION
This PR uses [mkdocs-htmlproofer-plugin](https://github.com/manuzhang/mkdocs-htmlproofer-plugin) to validate external URLs as part of the workflow to build docs.

A section has been added at the end of the Notion document to help fix the broken links locally, if the workflow fails: https://www.notion.so/code17-io/Docs-Building-0399b81cfd9844dab2424c2346b26f6a?pvs=4