### PR TITLE
Fix links in notebooks

### DIFF
--- a/src/docs/examples/enterprise-notebooks/dodgers.ipynb
+++ b/src/docs/examples/enterprise-notebooks/dodgers.ipynb
@@ -2101,7 +2101,7 @@
    "source": [
     "For convenience, we have built a wrapper around tsfresh.\n",
     "\n",
-    "As we have discussed in a [different notebook](https://nbviewer.jupyter.org/github/getml/getml-demo/blob/master/air_pollution_demo.ipynb), tsfresh consumes a lot of memory. To limit the memory consumption to a feasible level, we only use tsfresh's MinimalFCParameters and IndexBasedFCParameters, which are a superset of the TimeBasedFCParameters."
+    "As we have discussed in a [different notebook](https://github.com/getml/getml-demo/blob/master/air_pollution.ipynb), tsfresh consumes a lot of memory. To limit the memory consumption to a feasible level, we only use tsfresh's MinimalFCParameters and IndexBasedFCParameters, which are a superset of the TimeBasedFCParameters."
    ]
   },
   {
@@ -5944,7 +5944,7 @@
     "\n",
     "We have compared getML's feature learning algorithms to Prophet and tsfresh on a data set related to traffic on LA's 101 North freeway. We found that getML significantly outperforms both Prophet and tsfresh. These results are consistent with the view that relational learning is a powerful tool for time series analysis.\n",
     "\n",
-    "You are encouraged to reproduce these results. You will need [getML](https://getml.com/product) to do so. You can download it for free."
+    "You are encouraged to reproduce these results. You will need [getML](https://getml.com) to do so. You can download it for free."
    ]
   }
  ],

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/air_pollution_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/air_pollution_prop.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "As our example dataset, we use a publicly available dataset on air pollution in Beijing, China (https://archive.ics.uci.edu/dataset/381/beijing+pm2+5+data). For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/air_pollution/)."
+    "As our example dataset, we use a publicly available dataset on air pollution in Beijing, China (https://archive.ics.uci.edu/dataset/381/beijing+pm2+5+data). For further details about the data set refer to [the full notebook](https://getml.com/latest/examples/enterprise-notebooks/air_pollution/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/air_pollution_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/air_pollution_prop.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "As our example dataset, we use a publicly available dataset on air pollution in Beijing, China (https://archive.ics.uci.edu/dataset/381/beijing+pm2+5+data). For further details about the data set refer to [the full notebook](../air_pollution.ipynb)."
+    "As our example dataset, we use a publicly available dataset on air pollution in Beijing, China (https://archive.ics.uci.edu/dataset/381/beijing+pm2+5+data). For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/air_pollution/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/dodgers_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/dodgers_prop.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "In this notebook, we use traffic data that was collected for the Glendale on ramp for the 101 North freeway in Los Angeles. For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/dodgers/)."
+    "In this notebook, we use traffic data that was collected for the Glendale on ramp for the 101 North freeway in Los Angeles. For further details about the data set refer to [the full notebook](https://getml.com/latest/examples/enterprise-notebooks/dodgers/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/dodgers_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/dodgers_prop.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "In this notebook, we use traffic data that was collected for the Glendale on ramp for the 101 North freeway in Los Angeles. For further details about the data set refer to [the full notebook](../dodgers.ipynb)."
+    "In this notebook, we use traffic data that was collected for the Glendale on ramp for the 101 North freeway in Los Angeles. For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/dodgers/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/interstate94_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/interstate94_prop.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "In this notebook, we predict the hourly traffic volume on I-94 westbound from Minneapolis-St Paul. The analysis is built on top of a dataset provided by the [MN Department of Transportation](https://www.dot.state.mn.us), with some data preparation done by [John Hogue](https://github.com/dreyco676/Anomaly_Detection_A_to_Z/). For further details about the data set refer to [the full notebook](../interstate94.ipynb)."
+    "In this notebook, we predict the hourly traffic volume on I-94 westbound from Minneapolis-St Paul. The analysis is built on top of a dataset provided by the [MN Department of Transportation](https://www.dot.state.mn.us), with some data preparation done by [John Hogue](https://github.com/dreyco676/Anomaly_Detection_A_to_Z/). For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/interstate94/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/interstate94_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/interstate94_prop.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "In this notebook, we predict the hourly traffic volume on I-94 westbound from Minneapolis-St Paul. The analysis is built on top of a dataset provided by the [MN Department of Transportation](https://www.dot.state.mn.us), with some data preparation done by [John Hogue](https://github.com/dreyco676/Anomaly_Detection_A_to_Z/). For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/interstate94/)."
+    "In this notebook, we predict the hourly traffic volume on I-94 westbound from Minneapolis-St Paul. The analysis is built on top of a dataset provided by the [MN Department of Transportation](https://www.dot.state.mn.us), with some data preparation done by [John Hogue](https://github.com/dreyco676/Anomaly_Detection_A_to_Z/). For further details about the data set refer to [the full notebook](https://getml.com/latest/examples/enterprise-notebooks/interstate94/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/occupancy_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/occupancy_prop.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "Our use case here is a public domain data set for predicting room occupancy from sensor data. For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/occupancy/)."
+    "Our use case here is a public domain data set for predicting room occupancy from sensor data. For further details about the data set refer to [the full notebook](https://getml.com/latest/examples/enterprise-notebooks/occupancy/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/fastprop_benchmark/occupancy_prop.ipynb
+++ b/src/docs/examples/enterprise-notebooks/fastprop_benchmark/occupancy_prop.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "getML's [FastProp](https://docs.getml.com/latest/user_guide/feature_engineering/feature_engineering.html#fastprop) is an implementation of this propositionalization approach that has been optimized for speed and memory efficiency. In this notebook, we want to demonstrate how – well – fast FastProp is. To this end, we will benchmark FastProp against the popular feature engineering libraries [featuretools](https://www.featuretools.com/) and [tsfresh](https://tsfresh.readthedocs.io/en/latest/). Both of these libraries use propositionalization approaches for feature engineering.\n",
     "\n",
-    "Our use case here is a public domain data set for predicting room occupancy from sensor data. For further details about the data set refer to [the full notebook](../occupancy.ipynb)."
+    "Our use case here is a public domain data set for predicting room occupancy from sensor data. For further details about the data set refer to [the full notebook](/examples/enterprise-notebooks/occupancy/)."
    ]
   },
   {

--- a/src/docs/examples/enterprise-notebooks/occupancy.ipynb
+++ b/src/docs/examples/enterprise-notebooks/occupancy.ipynb
@@ -4465,7 +4465,7 @@
     "\n",
     "This tutorial demonstrates that relational learning is a powerful tool for time series. We able to outperform the benchmarks for a scientific paper on a simple public domain time series data set using relatively little effort.\n",
     "\n",
-    "If you want to learn more about getML, check out the [official documentation](https://getml.com/product)."
+    "If you want to learn more about getML, check out the [official documentation](https://getml.com)."
    ]
   }
  ],

--- a/src/mkdocs.yml
+++ b/src/mkdocs.yml
@@ -143,11 +143,16 @@ plugins:
   - htmlproofer:
       enabled: !ENV [ENABLED_HTMLPROOFER, False]
       raise_error_after_finish: True
+      raise_error_excludes:
+        403: [https://www.sciencedirect.com/science/article/abs/pii/S0378778815304357, 
+              https://www.researchgate.net/publication/228572841_Mining_episode_rules_in_STULONG_dataset]
       ignore_urls:
         - https://static.getml.com/download/1.5.0/*
         - https://storage.googleapis.com/static.getml.com/download/1.5.0/*
         - localhost:8080/*
         - mailto:*
+        - 'data:image/*'
+        - '#*'
 
 hooks:
   - docs/examples/get_notebooks.py


### PR DESCRIPTION
### Problem
- The introduction of https://github.com/getml/getml-docs/pull/73 recently [broke](https://github.com/getml/getml-docs/actions/runs/10418026968) the build workflow.

### Solution
- The broken links inside the example notebooks have been fixed 
- The false positives hits of broken links have been ignored.