### PR TITLE
Add minify plugin

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -20,10 +20,13 @@ jobs:
       GH_C17_DEV_TOKEN: ${{ secrets.GH_C17_DEV_TOKEN }}
       NOTEBOOKS_INCLUDE: '*.ipynb'
       ENABLED_HTMLPROOFER: ${{ vars.ENABLED_HTMLPROOFER || 'False' }}
+      ENABLED_GIT_COMMITTERS: 'true'
       JUPYTER_PLATFORM_DIRS: 1
     steps:
       - name: Checkout getml-docs repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -21,6 +21,7 @@ jobs:
       NOTEBOOKS_INCLUDE: '*.ipynb'
       ENABLED_HTMLPROOFER: ${{ vars.ENABLED_HTMLPROOFER || 'False' }}
       ENABLED_GIT_COMMITTERS: 'true'
+      ENABLED_MINIFY: 'true'
       JUPYTER_PLATFORM_DIRS: 1
     steps:
       - name: Checkout getml-docs repo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,11 +161,7 @@ plugins:
       enabled: !ENV [ENABLED_HTMLPROOFER, False]
       raise_error_after_finish: True
       raise_error_excludes:
-        403: [https://www.sciencedirect.com/science/article/abs/pii/S0378778815304357, 
-              https://www.researchgate.net/publication/228572841_Mining_episode_rules_in_STULONG_dataset,
-              https://archive.ics.uci.edu/ml/datasets/Epileptic+Seizure+Recognition]
         403: ['*']
-        
       ignore_urls:
         - https://static.getml.com/download/1.5.0/*
         - https://storage.googleapis.com/static.getml.com/download/1.5.0/*
@@ -179,6 +175,10 @@ plugins:
       repository: getml/getml-docs
       branch: develop
       token: !ENV [GH_C17_DEV_TOKEN, ""]
+  - minify:
+      minify_html: !ENV [ENABLED_MINIFY, False]
+      htmlmin_opts:
+        remove_comments: true
   
 hooks:
   - docs/examples/get_notebooks.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,7 +173,13 @@ plugins:
         - mailto:*
         - 'data:image/*'
         - '#*'
-
+  - git-revision-date-localized
+  - git-committers:
+      enabled: !ENV [ENABLED_GIT_COMMITTERS, false]
+      repository: getml/getml-docs
+      branch: develop
+      token: !ENV [GH_C17_DEV_TOKEN, ""]
+  
 hooks:
   - docs/examples/get_notebooks.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
   "mike~=2.1",
   "mkdocs-redirects~=1.2",
   "mkdocs-jupyter~=0.24.8",
-  "mkdocs-htmlproofer-plugin~=1.2"
+  "mkdocs-htmlproofer-plugin~=1.2",
+  "mkdocs-git-revision-date-localized-plugin~=1.2",
+  "mkdocs-git-committers-plugin-2~=2.3"
 ]
 python = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "mkdocs-jupyter~=0.24.8",
   "mkdocs-htmlproofer-plugin~=1.2",
   "mkdocs-git-revision-date-localized-plugin~=1.2",
-  "mkdocs-git-committers-plugin-2~=2.3"
+  "mkdocs-git-committers-plugin-2~=2.3",
+  "mkdocs-minify-plugin~=0.8.0"
 ]
 python = "3.11"


### PR DESCRIPTION
`minify` plugin helps reduce comments in HTML files. It reduced the comments from 22k to 1.3k.

To avoid conflicts, the base branch of `add-minify-plugin` branch is [add-footer](https://github.com/getml/getml-docs/tree/add-footer) branch. The corresponding PR #86 may be merged before merging this PR.