### PR TITLE
Add fork and hide footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,12 +169,22 @@ plugins:
         - mailto:*
         - 'data:image/*'
         - '#*'
-  - git-revision-date-localized
+  - git-revision-date-localized:
+      exclude:
+        - index.md
+        - enterprise/**
+        - about/**
+        - contact/**
   - git-committers:
       enabled: !ENV [ENABLED_GIT_COMMITTERS, false]
       repository: getml/getml-docs
       branch: develop
       token: !ENV [GH_C17_DEV_TOKEN, ""]
+      exclude:
+        - index.md
+        - enterprise/**
+        - about/**
+        - contact/**
   - minify:
       minify_html: !ENV [ENABLED_MINIFY, False]
       htmlmin_opts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.1"
 dependencies = [
   "mkdocs~=1.6",
   "mkdocstrings-python~=1.10",
-  "mkdocs-material @ git+https://{env:GH_C17_DEV_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.30-insiders-4.53.11",
+  "mkdocs-material @ git+https://{env:GH_C17_DEV_TOKEN}@github.com/getml/mkdocs-material-insiders.git",
   "mkdocs-table-reader-plugin~=2.2",
   "black~=24.4",
   "mike~=2.1",


### PR DESCRIPTION
- The source of the theme has been set to the latest version from the getML fork of `mkdocs-material-insiders`
-  Footer on Home, Enterprise, About & Contact subpages has been hidden