### PR TITLE
Update deployment logic

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - develop
-    tags:
-      - 'v*'
+      - main
+      - version-*
   workflow_dispatch:
 
 concurrency:
@@ -75,36 +75,59 @@ jobs:
           git fetch origin gh-pages --depth=1
 
       - name: Deploy dev version if develop branch
-        if: "github.ref == 'refs/heads/develop'"
+        if: github.ref == 'refs/heads/develop'
         run: |
           hatch run mike deploy dev
 
-      - name: Deploy release version if tag
-        if: "startsWith(github.ref, 'refs/tags/v')"
+      - name: Determine Project Version
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/version-')
         run: |
-          TAG_VERSION=$(echo "${{ github.ref }}" | sed -n 's/refs\/tags\/v\([0-9]\+\.[0-9]\+\).*/\1/p')
+          PROJECT_VERSION=$(hatch version | cut -d. -f1,2)
 
-          if [[ -z "$TAG_VERSION" ]]; then
-            echo "TAG_VERSION could not be obtained from ${{ github.ref }}. Make sure the tag has 'vX.Y' in the beginning (e.g v1.5). Exiting.."
+          if [[ -z "$PROJECT_VERSION" ]]; then
+            echo "PROJECT_VERSION could not be obtained from pyproject.toml. Make sure 
+              the version is specified in it (e.g 1.5.0). Exiting.."
             exit 1
           fi
 
-          LATEST_DEPLOYED_VERSION=$(hatch run mike list | grep -E '^[0-9]+\.[0-9]+' | awk '{print $1}' | sort -V | tail -n 1)
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
 
-          if [[ -z $LATEST_DEPLOYED_VERSION ]]; then
-            echo "No numbered deployed version found. Deploying $TAG_VERSION with the latest alias"
-            hatch run mike deploy $TAG_VERSION latest
+      - name: Deploy numbered version (latest) if main branch
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "Main branch detected."
 
-          elif [[ $(echo -e "$TAG_VERSION\n$LATEST_DEPLOYED_VERSION" | sort -V | tail -n 1) == "$TAG_VERSION" && "$TAG_VERSION" != "$LATEST_DEPLOYED_VERSION" ]]; then
-            echo "Tag version ($TAG_VERSION) is higher than the currently deployed latest version ($LATEST_DEPLOYED_VERSION). Deploying $TAG_VERSION with the latest alias"
-            hatch run mike deploy --update-aliases $TAG_VERSION latest
+          LATEST_DEPLOYED_VERSION=$(hatch run mike list | \
+            grep -E '^[0-9]+\.[0-9]+' | \
+            awk '{print $1}' | \
+            sort -V | \
+            tail -n 1)
+          
+          if [[ $(echo -e "$PROJECT_VERSION\n$LATEST_DEPLOYED_VERSION" | \
+            sort -V | tail -n 1) == "$PROJECT_VERSION" && \
+            "$PROJECT_VERSION" != "$LATEST_DEPLOYED_VERSION" ]]; then
+
+            echo "New release. Project version ($PROJECT_VERSION) is higher than the 
+              currently deployed latest version ($LATEST_DEPLOYED_VERSION). 
+              Deploying new version $PROJECT_VERSION with the latest alias"
+            hatch run mike deploy --update-aliases "$PROJECT_VERSION" latest
 
           else
-            echo "Tag version ($TAG_VERSION) is not higher than the currently deployed latest version ($LATEST_DEPLOYED_VERSION). Deploying $TAG_VERSION without updating the latest alias"
-            hatch run mike deploy $TAG_VERSION
-            
+            echo "Update of existing latest version. Project version ($PROJECT_VERSION) 
+              is not higher than the currently deployed latest version ($LATEST_DEPLOYED_VERSION). 
+              Deploying version $PROJECT_VERSION without updating the latest alias"
+            hatch run mike deploy "$PROJECT_VERSION"
+
           fi
 
+          - name: Deploy numbered version (old) if version branch
+          if: startsWith(github.ref, 'refs/heads/version-')
+          run: |
+            echo "Version branch detected."
+            echo "Update of existing old version. Deploying version $PROJECT_VERSION 
+              without updating the latest alias"
+            hatch run mike deploy "$PROJECT_VERSION"
+        
       - name: Add CNAME file
         run: |
           git checkout gh-pages


### PR DESCRIPTION
The deployment logic has been updated:
- mike version information is now obtained from `pyproject.toml`
- Push to `main` will deploy the latest version 
- Before the new release of the docs (e.g. 1.6), the latest commit in `main` should be tagged with old version number (1.5)
- For any changes to old version (1.5) when the HEAD of `main` corresponds to latest 1.6 version, a new `version-1.5` branch should be created from the commit tagged as 1.5. The pushes to `version-1.5` branch will update 1.5 version documentation.
- The trigger due to tags has been removed