### PR TITLE
Fix git revision date warnings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,8 @@ plugins:
         - enterprise/**
         - about/**
         - contact/**
+        - examples/enterprise-notebooks/**
+        - examples/integrations/**
   - git-committers:
       enabled: !ENV [ENABLED_GIT_COMMITTERS, false]
       repository: getml/getml-docs


### PR DESCRIPTION
Ignore some example pages to fixes warnings such as:
```
WARNING -  [git-revision-date-localized-plugin] '/Users/code17/getml-docs/docs/examples/enterprise-notebooks/kaggle_notebooks/getml-and-gnns-a-natural-symbiosis.ipynb' has no git logs, using current timestamp
WARNING -  [git-revision-date-localized-plugin] '/Users/code17/getml-docs/docs/examples/integrations/vertexai/vertexai.ipynb' has no git logs, using current timestamp
```